### PR TITLE
Add manual trigger for broken links check

### DIFF
--- a/.github/workflows/broken-links-check.yml
+++ b/.github/workflows/broken-links-check.yml
@@ -1,6 +1,7 @@
 name: Broken Links Check
 
 on:
+  workflow_dispatch:
   push:
   schedule:
     - cron: "0 12 * * 2,4,6" # At 12:00 on Tuesday, Thursday, and Saturday.


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to the Broken Links Check GitHub Actions workflow so it can be started manually from the Actions tab.

## Why

The workflow already runs on pushes and on its scheduled cadence, but there was no button-triggered path for ad hoc link checks.

## Impact

Maintainers can now run the Broken Links Check workflow on demand without changing the existing push or scheduled triggers.

## Validation

- Ran `git diff --check -- .github/workflows/broken-links-check.yml`
- Confirmed the committed diff only adds `workflow_dispatch`
